### PR TITLE
Added WithinRange extension

### DIFF
--- a/Mauve.Tests/Core/Extensibility/IComparableExtensionTests.cs
+++ b/Mauve.Tests/Core/Extensibility/IComparableExtensionTests.cs
@@ -18,8 +18,8 @@ namespace Mauve.Tests.Core.Extensibility
 
         #region Tests
 
-        [TestMethod()] public void RangeExceeded() => Assert.IsFalse(15.WithinRange(LowerBound, UpperBound));
-        [TestMethod()] public void WithinRange() => Assert.IsTrue(3.WithinRange(LowerBound, UpperBound));
+        [TestMethod("Range Exceeded")] public void RangeExceeded() => Assert.IsFalse(15.WithinRange(LowerBound, UpperBound));
+        [TestMethod("Within Range")] public void WithinRange() => Assert.IsTrue(3.WithinRange(LowerBound, UpperBound));
 
         #endregion
     }

--- a/Mauve.Tests/Core/Extensibility/IComparableExtensionTests.cs
+++ b/Mauve.Tests/Core/Extensibility/IComparableExtensionTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+using Mauve.Extensibility;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Mauve.Tests.Core.Extensibility
+{
+    [TestClass]
+    public class IComparableExtensionTests
+    {
+        #region Constants
+
+        private const int LowerBound = 1;
+        private const int UpperBound = 10;
+
+        #endregion
+
+        #region Tests
+
+        [TestMethod()] public void RangeExceeded() => Assert.IsFalse(15.WithinRange(LowerBound, UpperBound));
+        [TestMethod()] public void WithinRange() => Assert.IsTrue(3.WithinRange(LowerBound, UpperBound));
+
+        #endregion
+    }
+}

--- a/Mauve.Tests/Mauve.Tests.csproj
+++ b/Mauve.Tests/Mauve.Tests.csproj
@@ -49,10 +49,17 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Core\Extensibility\IComparableExtensionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mauve\Mauve.csproj">
+      <Project>{CEAB28E3-6023-45DE-8CD6-AE8F4FBC9651}</Project>
+      <Name>Mauve</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Mauve/Extensibility/IComparableExtensions.cs
+++ b/Mauve/Extensibility/IComparableExtensions.cs
@@ -7,6 +7,13 @@ namespace Mauve.Core.Extensibility
     /// </summary>
     public static class IComparableExtensions
     {
-
+        /// <summary>
+        /// Determines if the calling object's value is equal to or greater than the specified minimum value, while remaining less than or equal to the specified maximum value.
+        /// </summary>
+        /// <param name="value">The calling object's value.</param>
+        /// <param name="min">The minimum allowed value.</param>
+        /// <param name="max">The maximum allowed value.</param>
+        /// <returns>Returns true if the calling object's value is equal to or greater than the specified minimum value, while remaining less than or equal to the specified maximum value, otherwise false.</returns>
+        public static bool WithinRange(this IComparable value, IComparable min, IComparable max) => value.CompareTo(min) >= 0 && value.CompareTo(max) <= 0;
     }
 }

--- a/Mauve/Extensibility/IComparableExtensions.cs
+++ b/Mauve/Extensibility/IComparableExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Mauve.Core.Extensibility
+namespace Mauve.Extensibility
 {
     /// <summary>
     /// Represents a collection of extension methods for <see cref="IComparable"/> instances.

--- a/Mauve/Extensibility/IComparableExtensions.cs
+++ b/Mauve/Extensibility/IComparableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mauve.Core.Extensibility
+{
+    /// <summary>
+    /// Represents a collection of extension methods for <see cref="IComparable"/> instances.
+    /// </summary>
+    public static class IComparableExtensions
+    {
+
+    }
+}

--- a/Mauve/Mauve.csproj
+++ b/Mauve/Mauve.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensibility\IComparableExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This PR introduces an extension method for `IComparable` called `WithinRange` that allows for simplified range checking.