### PR TITLE
Removed products from issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -19,8 +19,6 @@ body:
       description: Which sub-product of Mauve is this feature for?
       options:
         - Ⓜ️ Framework
-        - 📝 Dapper Support Kit
-        - 💻 RestSharp Support Kit
         - 🦄 Visual Studio Community Extension
         - 🐲 Visual Studio Code Extension
     validations:

--- a/.github/ISSUE_TEMPLATE/extension.yml
+++ b/.github/ISSUE_TEMPLATE/extension.yml
@@ -12,17 +12,6 @@ body:
         - 🐣 Pre-Release
     validations:
       required: true
-  - type: dropdown
-    id: product
-    attributes:
-      label: 🌠 Product
-      description: Which sub-product of Mauve is this feature for?
-      options:
-        - Ⓜ️ Framework
-        - 📝 Dapper Support Kit
-        - 💻 RestSharp Support Kit
-    validations:
-      required: true
   - type: input
     attributes:
       label: 🦖 What type is this extension method for?

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -19,8 +19,6 @@ body:
       description: Which sub-product of Mauve is this feature for?
       options:
         - Ⓜ️ Framework
-        - 📝 Dapper Support Kit
-        - 💻 RestSharp Support Kit
         - 🦄 Visual Studio Community Extension
         - 🐲 Visual Studio Code Extension
     validations:

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -12,17 +12,6 @@ body:
         - 🐣 Pre-Release
     validations:
       required: true
-  - type: dropdown
-    id: product
-    attributes:
-      label: 🌠 Product
-      description: Which sub-product of Mauve is this test for?
-      options:
-        - Ⓜ️ Framework
-        - 📝 Dapper Support Kit
-        - 💻 RestSharp Support Kit
-    validations:
-      required: true
   - type: input
     attributes:
       label: 🦖 What type is this test for?


### PR DESCRIPTION
This PR removes `Dapper Support Kit` and `RestSharp Support Kit` from dropdown options in issue templates; effectively closing issue #88.